### PR TITLE
Added travis config and introduced lib-Werror flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: haskell
+
+ghc:
+  - 7.8
+  - 7.6
+  - 7.4
+
+before_install:
+  - ghc-pkg list
+  
+install:
+  - cabal install --dependencies-only --enable-tests
+  - cabal configure -flib-Werror --enable-tests
+  
+script:
+  - cabal build && cabal test
+  

--- a/ghc-pkg-lib.cabal
+++ b/ghc-pkg-lib.cabal
@@ -1,6 +1,6 @@
 name:           ghc-pkg-lib
 version:        0.2.1
-cabal-version:  >=1.20
+cabal-version:  >=1.14
 build-type:     Simple
 author:         Thiago Arrais, JP Moresmau
 maintainer:     jp@moresmau.fr
@@ -13,6 +13,10 @@ description:    A library that lists the installed packages in a given sandbox a
 category:       Development
 homepage:       https://github.com/JPMoresmau/ghc-pkg-lib
 
+flag lib-Werror
+  default: False
+  manual: True
+
 library
   hs-source-dirs:   src
   build-depends:   
@@ -20,10 +24,14 @@ library
                     ghc-paths >=0.1.0,
                     filepath,
                     directory,
-                    Cabal >=1.18
+                    ghc,
+                    Cabal >=1.14
   ghc-options:      -Wall
   exposed-modules:  Language.Haskell.Packages
   default-language: Haskell98
+  
+  if flag(lib-Werror)
+    ghc-options: -Werror
 
 source-repository head
   type:     git

--- a/src/Language/Haskell/Packages.hs
+++ b/src/Language/Haskell/Packages.hs
@@ -15,6 +15,7 @@ module Language.Haskell.Packages ( getPkgInfos ) where
 
 import Prelude hiding (Maybe)
 import qualified System.Info
+import qualified Config
 import Control.Applicative
 import Data.List
 import Data.Maybe
@@ -71,7 +72,7 @@ getPkgInfos msandbox=
     currentOS = System.Info.os
 
     ghcVersion :: String
-    ghcVersion = TOOL_VERSION_ghc
+    ghcVersion = Config.cProjectVersion
   in do
     -- Get the global package configuration database:
     global_conf <- do


### PR DESCRIPTION
When the lib-Werror flag is given, then ghc is invoked with -Werror. This is used for Travis CI builds so that warnings are noticed. Fixes #2.

Don't merge yet, work in progress!

The builds currently test against ghc 7.4.2, 7.6.3, and 7.8.3. cabal-install is 1.18. I used 1.18 as [ekmett/lens](https://github.com/ekmett/lens/blob/master/.travis.yml) does the same and this is also the version shipped with the latest Haskell platform. The .cabal file of ghc-pkg-lib requires `cabal-version:  >=1.20` though. Is this desired? If not, what should the minimum supported version be? `build-depends` has `Cabal >=1.18`, so maybe 1.18?

See https://travis-ci.org/neothemachine/ghc-pkg-lib/builds/45876480 for current build status.